### PR TITLE
manifesto: use parser.read_file()

### DIFF
--- a/manifesto
+++ b/manifesto
@@ -450,7 +450,7 @@ class MnfsParser(object):
         cfg_parser = configparser.ConfigParser(dict_type=collections.OrderedDict)
 
         with open(mnfs_file, 'r') as f:
-            cfg_parser.readfp(f)
+            cfg_parser.read_file(f)
 
         manifest = Manifest()
 


### PR DESCRIPTION
This change removes the only remaining warning in python3.

configparser.readfp() was deprecated in favour of
configparser.read_file()

Fixes #1